### PR TITLE
Adds standalone install description

### DIFF
--- a/cmd/routingkit/README.md
+++ b/cmd/routingkit/README.md
@@ -36,6 +36,15 @@ Build a binary by simply invoking
 go build
 ```
 
+### Install
+
+Install binary to `PATH`. Requires `$(go env GOPATH)/bin` to be included in
+`PATH`. After successful installation `routingkit` can be invoked as a command.
+
+```bash
+go install github.com/nextmv-io/go-routingkit/cmd/routingkit@latest
+```
+
 ### Arguments
 
 ```go


### PR DESCRIPTION
# Description

Adds a small description for installing _go-routingkit standalone_.

## Changes

- Adds an install description for _go-routingkit standalone_