### PR TITLE
Add ShrinkToHullRect function

### DIFF
--- a/.github/workflows/go-routingkit-compile-test.yml
+++ b/.github/workflows/go-routingkit-compile-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.19.3
         id: go
       - name: Compile
         run: |

--- a/.github/workflows/go-routingkit-compile-test.yml
+++ b/.github/workflows/go-routingkit-compile-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.12
+          go-version: 1.19
         id: go
       - name: Compile
         run: |

--- a/.github/workflows/go-routingkit-compile-test.yml
+++ b/.github/workflows/go-routingkit-compile-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - run: echo "Compiling for ${{matrix.os}}"

--- a/.github/workflows/go-routingkit-compile-test.yml
+++ b/.github/workflows/go-routingkit-compile-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.19.12
         id: go
       - name: Compile
         run: |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901192339-86cc279a91cc
+	github.com/nextmv-io/osm v0.0.0-20230901192722-53ca2374122e
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
+	github.com/nextmv-io/osm v0.0.0-20230901174516-c2da18ded1fd
 	github.com/paulmach/orb v0.1.6 // indirect
-	github.com/paulmach/osm v0.7.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nextmv-io/go-routingkit
 go 1.13
 
 require (
+	github.com/golang/geo v0.0.0-20230421003525-6adc56603217 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/nextmv-io/osm v0.0.0-20230902163833-fad147b7397c
 	github.com/paulmach/orb v0.1.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901174516-c2da18ded1fd
+	github.com/nextmv-io/osm v0.0.0-20230901181518-3b71c2a7bc01
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/paulmach/osm v0.2.2
+	github.com/paulmach/orb v0.1.6 // indirect
+	github.com/paulmach/osm v0.7.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/nextmv-io/go-routingkit
 go 1.13
 
 require (
-	github.com/golang/geo v0.0.0-20230421003525-6adc56603217 // indirect
+	github.com/golang/geo v0.0.0-20230421003525-6adc56603217
 	github.com/google/go-cmp v0.5.6
 	github.com/nextmv-io/osm v0.0.0-20230902163833-fad147b7397c
 	github.com/paulmach/orb v0.1.6 // indirect
+	github.com/twpayne/go-geom v1.5.2
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901181518-3b71c2a7bc01
+	github.com/nextmv-io/osm v0.0.0-20230901190258-a6a7508424e0
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/golang/geo v0.0.0-20230421003525-6adc56603217
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230902163833-fad147b7397c
+	github.com/nextmv-io/osm v0.0.0-20230906140741-44f1f4ec7cce
 	github.com/paulmach/orb v0.1.6 // indirect
 	github.com/twpayne/go-geom v1.5.2
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901192722-53ca2374122e
+	github.com/nextmv-io/osm v0.0.0-20230901201652-99a5385d4cfb
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901190258-a6a7508424e0
+	github.com/nextmv-io/osm v0.0.0-20230901192339-86cc279a91cc
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/golang/geo v0.0.0-20230421003525-6adc56603217
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230906140741-44f1f4ec7cce
+	github.com/nextmv-io/osm v0.0.1
 	github.com/paulmach/orb v0.1.6 // indirect
-	github.com/twpayne/go-geom v1.5.2
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.6
-	github.com/nextmv-io/osm v0.0.0-20230901201652-99a5385d4cfb
+	github.com/nextmv-io/osm v0.0.0-20230902163833-fad147b7397c
 	github.com/paulmach/orb v0.1.6 // indirect
 )

--- a/routingkit/routingkit.go
+++ b/routingkit/routingkit.go
@@ -549,18 +549,20 @@ func getNodes(osmFile string, nodeIds map[osm.NodeID]struct{}) ([]*osm.Node, err
 	scanner := osmpbf.New(context.Background(), file, runtime.GOMAXPROCS(0))
 	scanner.SkipWays = true
 	scanner.SkipRelations = true
+	scanner.FilterNode = func(n *osm.Node) bool {
+		_, ok := nodeIds[n.ID]
+		return ok
+	}
 	defer scanner.Close()
 
 	nodes := []*osm.Node{}
 	for scanner.Scan() {
 		switch o := scanner.Object().(type) {
 		case *osm.Node:
-			if _, ok := nodeIds[o.ID]; ok {
-				// remove unnecessary data
-				o.Committed = nil
-				o.User = ""
-				nodes = append(nodes, o)
-			}
+			// remove unnecessary data
+			o.Committed = nil
+			o.User = ""
+			nodes = append(nodes, o)
 		}
 	}
 

--- a/routingkit/routingkit.go
+++ b/routingkit/routingkit.go
@@ -501,6 +501,11 @@ func Shrink(osmFile string, tagMapFilter TagMapFilter, outputFile string) error 
 			id := int(o.ID)
 			tagMap := o.Tags.Map()
 			if tagMapFilter != nil && tagMapFilter(id, tagMap) {
+				// remove unnecessary data
+				o.Updates = nil
+				o.Committed = nil
+				o.User = ""
+
 				ways = append(ways, o)
 				for _, node := range o.Nodes {
 					nodeIds[node.ID] = struct{}{}
@@ -520,6 +525,9 @@ func Shrink(osmFile string, tagMapFilter TagMapFilter, outputFile string) error 
 		switch o := scanner.Object().(type) {
 		case *osm.Node:
 			if _, ok := nodeIds[o.ID]; ok {
+				// remove unnecessary data
+				o.Committed = nil
+				o.User = ""
 				nodes = append(nodes, o)
 			}
 		}
@@ -530,8 +538,9 @@ func Shrink(osmFile string, tagMapFilter TagMapFilter, outputFile string) error 
 	}
 
 	osm := osm.OSM{
-		Ways:  ways,
-		Nodes: nodes,
+		Version: 0.6,
+		Ways:    ways,
+		Nodes:   nodes,
 	}
 
 	bytes, err := xml.Marshal(osm)

--- a/routingkit/routingkit.go
+++ b/routingkit/routingkit.go
@@ -517,6 +517,7 @@ func Shrink(osmFile string, tagMapFilter TagMapFilter, outputFile string) error 
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 	writer, err := osmpbf.NewWriter(file)
 	if err != nil {
 		return err

--- a/routingkit/routingkit.go
+++ b/routingkit/routingkit.go
@@ -502,7 +502,7 @@ func Shrink(osmFile string, tagMapFilter TagMapFilter, outputFile string) error 
 	defer file.Close()
 
 	// The third parameter is the number of parallel decoders to use.
-	scanner := osmpbf.New(context.Background(), file, runtime.GOMAXPROCS(0))
+	scanner := osmpbf.New(context.Background(), file, 1)
 	scanner.SkipNodes = true
 	scanner.SkipRelations = true
 	scanner.FilterWay = func(w *osm.Way) bool {
@@ -560,7 +560,7 @@ func getNodes(osmFile string, nodeIds map[osm.NodeID]struct{}, writer osmpbf.Wri
 	}
 	defer file.Close()
 	// The third parameter is the number of parallel decoders to use.
-	scanner := osmpbf.New(context.Background(), file, runtime.GOMAXPROCS(0))
+	scanner := osmpbf.New(context.Background(), file, 1)
 	scanner.SkipWays = true
 	scanner.SkipRelations = true
 	scanner.FilterNode = func(n *osm.Node) bool {

--- a/routingkit/routingkit.go
+++ b/routingkit/routingkit.go
@@ -494,7 +494,8 @@ func (c *TravelTimeClient) SetSnapRadius(n float32) {
 // containing only the ways and nodes that are within the bounding box of the
 // convex hull of the given points expanded by the given margin in meters. It
 // will also remove any ways that do not pass the given tagMapFilter. The
-// returned [][]float64 is the expanded bounding box.
+// returned [][]float64 holds the lower left and upper right lon/lat coordinates
+// describing the expanded bounding box.
 func ShrinkToHullRect(
 	pbfFile io.ReadSeeker,
 	tagMapFilter TagMapFilter,

--- a/routingkit/routingkit_test.go
+++ b/routingkit/routingkit_test.go
@@ -224,7 +224,12 @@ func TestShrunkMatrix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("creating file: %v", err)
 		}
-		err = routingkit.Shrink(marylandMap, test.profile.Filter, file)
+		allPoints := append(test.sources, test.destinations...)
+		originalPbf, err := os.Open(marylandMap)
+		if err != nil {
+			t.Fatalf("opening file: %v", err)
+		}
+		_, err = routingkit.ShrinkToHullRect(originalPbf, test.profile.Filter, allPoints, 100, file)
 		if err != nil {
 			t.Fatalf("shrinking: %v", err)
 		}


### PR DESCRIPTION
# Description

Adds a new function `ShrinkToHullRect`.

ShrinkToHullRect writes a new .osm.pbf file to the given pbfOutput writer containing only the ways and nodes that are within the bounding box of the convex hull of the given points expanded by the given margin in meters. It will also remove any ways that do not pass the given tagMapFilter. The returned [][]float64 holds the lower left and upper right lon/lat coordinates describing the expanded bounding box.